### PR TITLE
[FEAT] 게시판 주인 여부에 따른 UI분기 처리

### DIFF
--- a/src/apis/api/get/useGetEncryptedSceneIds.ts
+++ b/src/apis/api/get/useGetEncryptedSceneIds.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { authClient } from "../../client";
-import { SceneResponse } from "@/types/scene.types";
 
 /**
  * 암호화된 Scene ID를 사용하여 Scene 정보를 조회하는 훅입니다.
@@ -8,11 +7,11 @@ import { SceneResponse } from "@/types/scene.types";
  * @param encryptedSceneIds - 암호화된 Scene ID
  */
 export const useGetEncryptedSceneIds = (encryptedSceneIds: string) => {
-  return useQuery<SceneResponse, Error>({
+  return useQuery({
     queryKey: ["sceneIds", encryptedSceneIds],
     queryFn: async () => {
       const { data } = await authClient.get(`/scenes/${encryptedSceneIds}`);
-      return data as SceneResponse;
+      return data;
     },
     enabled: !!encryptedSceneIds,
   });

--- a/src/apis/api/get/useGetScenes.ts
+++ b/src/apis/api/get/useGetScenes.ts
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { authClient } from "../../client";
-import { SceneResponse } from "@/types/scene.types";
 
 /**
  * 사용자의 모든 Scene 목록을 불러오는 훅입니다.
@@ -8,11 +7,11 @@ import { SceneResponse } from "@/types/scene.types";
  * - 로딩 중에도 placeholderData([])로 안전하게 처리됨
  */
 export const useGetScenes = () => {
-  return useQuery<SceneResponse[], Error>({
+  return useQuery({
     queryKey: ["scenes"],
     queryFn: async () => {
       const { data } = await authClient.get("/scenes");
-      return data as SceneResponse[];
+      return data;
     },
     placeholderData: [], // 로딩 중에도 빈 배열로 초기값 제공
   });

--- a/src/apis/api/get/useGetScenes.ts
+++ b/src/apis/api/get/useGetScenes.ts
@@ -13,6 +13,6 @@ export const useGetScenes = () => {
       const { data } = await authClient.get("/scenes");
       return data;
     },
-    placeholderData: [], // 로딩 중에도 빈 배열로 초기값 제공
+    placeholderData: "",
   });
 };

--- a/src/components/common/SceneRedirector.tsx
+++ b/src/components/common/SceneRedirector.tsx
@@ -17,11 +17,10 @@ const SceneRedirector = () => {
 
     // 이미 경로가 scene id 형태라면 아무것도 하지 않음
     const currentPath = location.pathname;
-    const isScenePath = /^\/[a-zA-Z0-9_-]+$/.test(currentPath);
+    const isScenePath = /^\/[a-zA-Z0-9+/=_-]+$/.test(currentPath);
     if (isScenePath) {
       return;
     }
-    console.log(scenes);
     // scene 목록 받아왔을 때 첫 번째 encryptedSceneId로 이동
     if (isSuccess && scenes) {
       navigate(`/${scenes.data}`, { replace: true });

--- a/src/components/common/SceneRedirector.tsx
+++ b/src/components/common/SceneRedirector.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/store/authStore";
+import { useGetScenes } from "@/apis/api/get/useGetScenes";
+
+const SceneRedirector = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isAuthenticated } = useAuthStore();
+  const { data: scenes, isSuccess } = useGetScenes();
+
+  useEffect(() => {
+    // 인증되지 않은 경우 리다이렉션 처리 X
+    if (!isAuthenticated) {
+      return;
+    }
+
+    // 이미 경로가 scene id 형태라면 아무것도 하지 않음
+    const currentPath = location.pathname;
+    const isScenePath = /^\/[a-zA-Z0-9_-]+$/.test(currentPath);
+    if (isScenePath) {
+      return;
+    }
+    console.log(scenes);
+    // scene 목록 받아왔을 때 첫 번째 encryptedSceneId로 이동
+    if (isSuccess && scenes) {
+      navigate(`/${scenes.data}`, { replace: true });
+    }
+  }, [isAuthenticated, isSuccess, scenes, navigate, location.pathname]);
+
+  return null;
+};
+
+export default SceneRedirector;

--- a/src/components/scene/ButtonLg.tsx
+++ b/src/components/scene/ButtonLg.tsx
@@ -1,13 +1,10 @@
 import { Button } from "@/components/ui/button";
 
-const mockData = {
-  title: "🫧 버블 공유하기",
-};
-
-export function ButtonLg() {
+export function ButtonLg({ isOwner }: { isOwner: boolean }) {
+  const BUTTON_TEXT = isOwner ? "🫧 버블 공유하기" : "🫧 버블 남기기";
   return (
     <Button className="bg-gray-50 font-jua rounded-2xl mb-[10%] h-[3rem] text-xl shadow-lg">
-      {mockData.title}
+      {BUTTON_TEXT}
     </Button>
   );
 }

--- a/src/components/scene/Cloud.tsx
+++ b/src/components/scene/Cloud.tsx
@@ -1,12 +1,12 @@
 import { Canvas } from "@react-three/fiber";
 import { Environment } from "@react-three/drei";
-import { DEFAULT_ENVIRONMENT_PRESET } from "@/lib/constants";
+import { EnvironmentPreset } from "@/lib/constants";
 
-export default function Cloud() {
+export default function Cloud({ preset }: { preset: EnvironmentPreset }) {
   return (
     <div className="w-full h-full">
       <Canvas camera={{ fov: 75, position: [0, 0, 5] }}>
-        <Environment preset={DEFAULT_ENVIRONMENT_PRESET} background blur={1} />
+        <Environment preset={preset} background blur={1} />
       </Canvas>
     </div>
   );

--- a/src/components/scene/ProfileHeader.tsx
+++ b/src/components/scene/ProfileHeader.tsx
@@ -12,7 +12,7 @@ export function ProfileHeader({ userData }: { userData: UserData }) {
       <div className="inline-flex items-center justify-center gap-[0.5rem] p-0 font-jua h-max  text-xl">
         <Avatar>
           <AvatarImage src={userData.profileImage} alt="userProfile" />
-          <AvatarFallback>user</AvatarFallback>
+          <AvatarFallback>KO</AvatarFallback>
         </Avatar>
         <span>{userData.nickName}님의 버블</span>
       </div>

--- a/src/components/scene/ProfileHeader.tsx
+++ b/src/components/scene/ProfileHeader.tsx
@@ -1,41 +1,20 @@
-import { useEffect, useState } from "react";
 import { Avatar, AvatarImage, AvatarFallback } from "../ui/avatar";
 import { Card } from "../ui/card";
 
-interface UserData {
-  nickname: string;
-  profileImageUrl: string;
+export interface UserData {
+  nickName: string;
+  profileImage: string;
 }
 
-export function ProfileHeader() {
-  const [userData, setUserData] = useState<UserData | null>(null);
-
-  useEffect(() => {
-    const storedAuth = localStorage.getItem("auth-storage");
-    if (storedAuth) {
-      try {
-        const parsed = JSON.parse(storedAuth);
-        const nickname = parsed.state?.user?.nickname;
-        const profileImageUrl = parsed.state?.user?.profileImageUrl;
-        if (nickname && profileImageUrl) {
-          setUserData({ nickname, profileImageUrl });
-        }
-      } catch (e) {
-        console.error("Error parsing auth-storage:", e);
-      }
-    }
-  }, []);
-
-  if (!userData) return null;
-
+export function ProfileHeader({ userData }: { userData: UserData }) {
   return (
     <Card className="inline-block items-center justify-center rounded-2xl px-[0.7rem] py-[0.5rem] border-none bg-gray-50 w-max h-[3rem] shadow-lg">
       <div className="inline-flex items-center justify-center gap-[0.5rem] p-0 font-jua h-max  text-xl">
         <Avatar>
-          <AvatarImage src={userData.profileImageUrl} alt="userProfile" />
+          <AvatarImage src={userData.profileImage} alt="userProfile" />
           <AvatarFallback>user</AvatarFallback>
         </Avatar>
-        <span>{userData.nickname}님의 버블</span>
+        <span>{userData.nickName}님의 버블</span>
       </div>
     </Card>
   );

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -13,4 +13,4 @@ export const ENVIRONMENT_PRESETS = [
 
 export type EnvironmentPreset = (typeof ENVIRONMENT_PRESETS)[number];
 
-export const DEFAULT_ENVIRONMENT_PRESET: EnvironmentPreset = "dawn";
+export const DEFAULT_ENVIRONMENT_PRESET: EnvironmentPreset = "sunset";

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,8 @@
+export const DEFAULT_USER_DATA = {
+  nickName: "사용자",
+  profileImage: "https://www.gravatar.com/avatar/?d=mp",
+};
+
 export const ENVIRONMENT_PRESETS = [
   "sunset",
   "dawn",

--- a/src/pages/ScenePage.tsx
+++ b/src/pages/ScenePage.tsx
@@ -9,6 +9,7 @@ import {
   ENVIRONMENT_PRESETS,
   DEFAULT_ENVIRONMENT_PRESET,
   EnvironmentPreset,
+  DEFAULT_USER_DATA,
 } from "@/lib/constants";
 
 export const ScenePage = () => {
@@ -16,7 +17,7 @@ export const ScenePage = () => {
   const { isSuccess, data } = useGetEncryptedSceneIds(encryptedSceneId ?? "");
   const { user, isAuthenticated } = useAuthStore();
 
-  const [userData, setUserData] = useState({ nickName: "", profileImage: "" });
+  const [userData, setUserData] = useState(DEFAULT_USER_DATA);
   const [isOwner, setIsOwner] = useState(false);
   const [backgroundPreset, setBackgroundPreset] = useState<EnvironmentPreset>(
     DEFAULT_ENVIRONMENT_PRESET

--- a/src/pages/ScenePage.tsx
+++ b/src/pages/ScenePage.tsx
@@ -3,6 +3,7 @@ import { useGetEncryptedSceneIds } from "@/apis/api/get/useGetEncryptedSceneIds"
 import { ButtonLg } from "@/components/scene/ButtonLg";
 import Cloud from "@/components/scene/Cloud";
 import { ProfileHeader } from "@/components/scene/ProfileHeader";
+import { useAuthStore } from "@/store/authStore";
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
@@ -10,14 +11,21 @@ export const ScenePage = () => {
   const { encryptedSceneId } = useParams<{ encryptedSceneId: string }>();
   const { isSuccess, data } = useGetEncryptedSceneIds(encryptedSceneId ?? "");
   const [userData, setUserData] = useState({ nickName: "", profileImage: "" });
+  const [isOwner, setIsOwner] = useState(false);
+  const { user, isAuthenticated } = useAuthStore();
+
   useEffect(() => {
     if (isSuccess) {
+      // UI용 데이터 정제
       setUserData({
         nickName: data.data.ownerNickname,
         profileImage: data.data.ownerProfileImage,
       });
+      if (isAuthenticated && user?.email == data.data.ownerSocialId) {
+        setIsOwner(true);
+      }
     }
-  }, [isSuccess]);
+  }, [isSuccess, data]);
 
   return (
     <div className="relative w-screen h-screen overflow-hidden">
@@ -27,8 +35,7 @@ export const ScenePage = () => {
 
       <div className="relative z-10 flex flex-col h-full justify-between px-[5%] py-[5%]">
         <ProfileHeader userData={userData} />
-        <div>{encryptedSceneId}</div>
-        <ButtonLg />
+        <ButtonLg isOwner={isOwner} />
       </div>
     </div>
   );

--- a/src/pages/ScenePage.tsx
+++ b/src/pages/ScenePage.tsx
@@ -1,11 +1,14 @@
 import { ButtonLg } from "@/components/scene/ButtonLg";
 import { ProfileHeader } from "@/components/scene/ProfileHeader";
+import { useParams } from "react-router-dom";
 
 export const ScenePage = () => {
+  const { encryptedSceneId } = useParams<{ encryptedSceneId: string }>();
+
   return (
     <div className="bg-gray-600 h-screen flex flex-col px-[5%] py-[5%] justify-between">
       <ProfileHeader />
-
+      <div>{encryptedSceneId}</div>
       <ButtonLg />
     </div>
   );

--- a/src/pages/ScenePage.tsx
+++ b/src/pages/ScenePage.tsx
@@ -1,22 +1,30 @@
-// import { useGetScenes } from "@/apis/api/get/useGetScenes";
+import { useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
 import { useGetEncryptedSceneIds } from "@/apis/api/get/useGetEncryptedSceneIds";
 import { ButtonLg } from "@/components/scene/ButtonLg";
 import Cloud from "@/components/scene/Cloud";
 import { ProfileHeader } from "@/components/scene/ProfileHeader";
 import { useAuthStore } from "@/store/authStore";
-import { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import {
+  ENVIRONMENT_PRESETS,
+  DEFAULT_ENVIRONMENT_PRESET,
+  EnvironmentPreset,
+} from "@/lib/constants";
 
 export const ScenePage = () => {
   const { encryptedSceneId } = useParams<{ encryptedSceneId: string }>();
   const { isSuccess, data } = useGetEncryptedSceneIds(encryptedSceneId ?? "");
-  const [userData, setUserData] = useState({ nickName: "", profileImage: "" });
-  const [isOwner, setIsOwner] = useState(false);
   const { user, isAuthenticated } = useAuthStore();
 
+  const [userData, setUserData] = useState({ nickName: "", profileImage: "" });
+  const [isOwner, setIsOwner] = useState(false);
+  const [backgroundPreset, setBackgroundPreset] = useState<EnvironmentPreset>(
+    DEFAULT_ENVIRONMENT_PRESET
+  );
+
   useEffect(() => {
+    //UI용 데이터 정제
     if (isSuccess) {
-      // UI용 데이터 정제
       setUserData({
         nickName: data.data.ownerNickname,
         profileImage: data.data.ownerProfileImage,
@@ -25,17 +33,35 @@ export const ScenePage = () => {
         setIsOwner(true);
       }
     }
-  }, [isSuccess, data]);
+  }, [isSuccess, data, isAuthenticated]);
 
   return (
     <div className="relative w-screen h-screen overflow-hidden">
       <div className="absolute inset-0 z-0">
-        <Cloud />
+        <Cloud preset={backgroundPreset} />
       </div>
 
       <div className="relative z-10 flex flex-col h-full justify-between px-[5%] py-[5%]">
         <ProfileHeader userData={userData} />
         <ButtonLg isOwner={isOwner} />
+
+        {isOwner && (
+          <div className="flex flex-wrap gap-2 mt-6">
+            {ENVIRONMENT_PRESETS.map((preset) => (
+              <button
+                key={preset}
+                onClick={() => setBackgroundPreset(preset)}
+                className={`px-3 py-1 rounded-xl text-sm shadow-md transition ${
+                  preset === backgroundPreset
+                    ? "bg-black text-white"
+                    : "bg-white text-black hover:bg-gray-100"
+                }`}
+              >
+                {preset}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/ScenePage.tsx
+++ b/src/pages/ScenePage.tsx
@@ -1,10 +1,23 @@
+// import { useGetScenes } from "@/apis/api/get/useGetScenes";
+import { useGetEncryptedSceneIds } from "@/apis/api/get/useGetEncryptedSceneIds";
 import { ButtonLg } from "@/components/scene/ButtonLg";
 import Cloud from "@/components/scene/Cloud";
 import { ProfileHeader } from "@/components/scene/ProfileHeader";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 export const ScenePage = () => {
   const { encryptedSceneId } = useParams<{ encryptedSceneId: string }>();
+  const { isSuccess, data } = useGetEncryptedSceneIds(encryptedSceneId ?? "");
+  const [userData, setUserData] = useState({ nickName: "", profileImage: "" });
+  useEffect(() => {
+    if (isSuccess) {
+      setUserData({
+        nickName: data.data.ownerNickname,
+        profileImage: data.data.ownerProfileImage,
+      });
+    }
+  }, [isSuccess]);
 
   return (
     <div className="relative w-screen h-screen overflow-hidden">
@@ -13,7 +26,8 @@ export const ScenePage = () => {
       </div>
 
       <div className="relative z-10 flex flex-col h-full justify-between px-[5%] py-[5%]">
-        <ProfileHeader />
+        <ProfileHeader userData={userData} />
+        <div>{encryptedSceneId}</div>
         <ButtonLg />
       </div>
     </div>

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,13 +1,17 @@
 import { Route, Routes } from "react-router-dom";
 import { ScenePage } from "@/pages/ScenePage";
 import KakaoAuthCallback from "@/pages/KakaoAuthCallback.tsx";
+import SceneRedirector from "@/components/common/SceneRedirector";
 
 const AppRoutes = () => {
   return (
-    <Routes>
-      <Route path="/:encryptedSceneId" element={<ScenePage />} />
-      <Route path="/auth/login/kakao" element={<KakaoAuthCallback />} />
-    </Routes>
+    <>
+      <SceneRedirector />
+      <Routes>
+        <Route path="/:encryptedSceneId" element={<ScenePage />} />
+        <Route path="/auth/login/kakao" element={<KakaoAuthCallback />} />
+      </Routes>
+    </>
   );
 };
 

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -5,7 +5,7 @@ import KakaoAuthCallback from "@/pages/KakaoAuthCallback.tsx";
 const AppRoutes = () => {
   return (
     <Routes>
-      <Route path="/" element={<ScenePage />} />
+      <Route path="/:encryptedSceneId" element={<ScenePage />} />
       <Route path="/auth/login/kakao" element={<KakaoAuthCallback />} />
     </Routes>
   );


### PR DESCRIPTION
## 유형
- 기능 추가

## 설명
- 암호화된 sceneId를 가진 pathName으로 이동 시 localStorage내 데이터를 비교해 owner, guest신분을 판단합니다.
- owner신분은 하단 버블 공유하기 버튼, 배경 색 전환 버튼 활성화
- guest신분은 하단 버블 작성하기 버튼 활성화
- / (rootpath)로 접근 시 사용자 로그인 여부를 판단하고 로그인 사용자인 경우 sceneId pathName으로 이동시킵니다
![image](https://github.com/user-attachments/assets/6556252c-802c-4a16-8429-fad839053e66)
![image](https://github.com/user-attachments/assets/61c38a3c-f2f0-45d0-aad0-ebbe656e6340)
- 로딩 중인 경우 default Profile image와 default User Name인 사용자로 profile이 대체 됩니다 [UI논의 필요]

## 이슈
close #25 
