### PR TITLE
[FEAT] useWeatherQuery 훅 추가 및 날씨에 따른 Rain Layer 추가

### DIFF
--- a/src/apis/api/get/useWeatherQuery.ts
+++ b/src/apis/api/get/useWeatherQuery.ts
@@ -26,6 +26,5 @@ export const useWeatherQuery = () => {
         description: weather.description,
       };
     },
-    staleTime: 1000 * 60 * 10,
   });
 };

--- a/src/components/scene/Cloud.tsx
+++ b/src/components/scene/Cloud.tsx
@@ -1,12 +1,18 @@
 import { Canvas } from "@react-three/fiber";
 import { Environment } from "@react-three/drei";
 import { DEFAULT_ENVIRONMENT_PRESET } from "@/lib/constants";
+import RainLayer from "./RainLayer";
+import { useWeatherQuery } from "@/hooks/useWeatherQuery";
+import { isRainy } from "@/utils/weatherUtils";
 
 export default function Cloud() {
+  const { data: weather, isLoading } = useWeatherQuery();
+
   return (
     <div className="w-full h-full">
       <Canvas camera={{ fov: 75, position: [0, 0, 5] }}>
         <Environment preset={DEFAULT_ENVIRONMENT_PRESET} background blur={1} />
+        {!isLoading && weather?.id && isRainy(weather.id) && <RainLayer />}
       </Canvas>
     </div>
   );

--- a/src/components/scene/Cloud.tsx
+++ b/src/components/scene/Cloud.tsx
@@ -2,7 +2,7 @@ import { Canvas } from "@react-three/fiber";
 import { Environment } from "@react-three/drei";
 import { EnvironmentPreset } from "@/lib/constants";
 import RainLayer from "./RainLayer";
-import { useWeatherQuery } from "@/hooks/useWeatherQuery";
+import { useWeatherQuery } from "@/apis/api/get/useWeatherQuery";
 import { isRainy } from "@/utils/weatherUtils";
 
 export default function Cloud({ preset }: { preset: EnvironmentPreset }) {

--- a/src/components/scene/RainLayer.tsx
+++ b/src/components/scene/RainLayer.tsx
@@ -1,0 +1,58 @@
+import { PointMaterial, Points } from "@react-three/drei";
+import { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+export default function RainLayer({ count = 1000 }: { count?: number }) {
+  // 비 입자의 초기 위치를 생성
+  const positions = useMemo(() => {
+    const arr = new Float32Array(count * 3);
+    for (let i = 0; i < count * 3; i += 3) {
+      arr[i] = (Math.random() - 0.5) * 20; // X 좌표
+      arr[i + 1] = Math.random() * 20 - 10; // Y 좌표
+      arr[i + 2] = (Math.random() - 1) * 20; // Z 좌표
+    }
+    return arr;
+  }, [count]);
+
+  // 비 입자의 속도를 생성
+  const velocities = useMemo(() => {
+    const arr = new Float32Array(count);
+    for (let i = 0; i < count; i++) {
+      arr[i] = Math.random() * 1 + 0.01; // 속도
+    }
+    return arr;
+  }, [count]);
+
+  const pointsRef = useRef<THREE.Points>(null);
+  useFrame(() => {
+    if (!pointsRef.current) return;
+
+    const positionsArray = pointsRef.current.geometry.attributes.position.array as Float32Array;
+
+    for (let i = 0; i < count * 3; i += 3) {
+      // Y 좌표를 감소시켜 비가 떨어지도록 함
+      positionsArray[i + 1] -= velocities[i / 3];
+
+      // 비가 화면 아래로 사라지면 다시 위로 리셋
+      if (positionsArray[i + 1] < -10) {
+        positionsArray[i + 1] = 10; // Y 좌표 리셋
+      }
+    }
+
+    pointsRef.current.geometry.attributes.position.needsUpdate = true;
+  });
+
+  return (
+    <Points ref={pointsRef} positions={positions} frustumCulled>
+      <PointMaterial
+        transparent
+        color="#a0c4ff"
+        size={0.08}
+        sizeAttenuation
+        depthWrite={false}
+        opacity={0.8}
+      />
+    </Points>
+  );
+}

--- a/src/hooks/useWeatherQuery.ts
+++ b/src/hooks/useWeatherQuery.ts
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { getUserLocation } from "@/lib/geolocation";
+import { getWeatherByCoords } from "@/apis/api/get/getWeather";
+
+export type WeatherData = {
+  id: number;
+  main: string;
+  description: string;
+};
+
+export const useWeatherQuery = () => {
+  return useQuery<WeatherData>({
+    queryKey: ["weather"],
+    queryFn: async () => {
+      const { lat, lon } = await getUserLocation();
+      const data = await getWeatherByCoords(lat, lon);
+
+      if (!data.weather || data.weather.length === 0) {
+        throw new Error("날씨 정보를 찾을 수 없습니다.");
+      }
+
+      const weather = data.weather[0];
+      return {
+        id: weather.id,
+        main: weather.main,
+        description: weather.description,
+      };
+    },
+    staleTime: 1000 * 60 * 10,
+  });
+};

--- a/src/utils/weatherUtils.ts
+++ b/src/utils/weatherUtils.ts
@@ -1,0 +1,8 @@
+// 비와 관련된 id인지 체크
+export function isRainy(id: number) {
+  return (
+    (id >= 200 && id < 300) || // Thunderstorm
+    (id >= 300 && id < 400) || // Drizzle
+    (id >= 500 && id < 600) // Rain
+  );
+}


### PR DESCRIPTION
## 유형
- 기능 추가


## 설명
- `useWeatherQuery` 훅 추가
- `RainLayer` 컴포넌트 추가
- 비와 관련한 날씨 코드인지 확인하는 `isRainy` 함수 유틸리티 파일에 구현
- `Cloud`에서 `useWeatherQuery()`로 날씨 상태 받아와서 비가 오는지 체크하여 비가 오면 `RainLayer` 렌더링

- 비 말고도 흐림(Clouds), 맑음(Clear) 등 다양한 날씨 Layer를 추가하려 했지만 
  - `Cloud` 컴포넌트의 `Environment`에 blur 처리가 되어있어 다양한 레이어를 추가하지 못함 
  - 추후 회의를 통해 다양한 날씨에 대한 레이어를 처리할 것인지, 한다면 어떻게 할 것인지 이야기 해봐야 함
 
## 테스트
1. `.env` 파일 추가 (OpenWeather API KEY 저장)
2. `RainLayer`가 잘 나오는지 확인하기 위해서는 비가 내리는 지역의 위도/경도로 날씨 정보를 받아와야 함
3. 만약 테스트할 때 현재 있는 지역에 비가 내리고 있지 않다면, `useWeatherQuery`에서 queryFn 부분에
```
      // const { lat, lon } = await getUserLocation();
      // const data = await getWeatherByCoords(lat, lon);
      const data = await getWeatherByCoords(31.230416, 121.473701);
```
이런 식으로 임의로 위도/경도를 넣어서 RainLayer가 비가 내릴 때 잘 나오는지 확인할 수 있음
 
아래 스크린샷은 임의로 위도/경도를 넣어서 비가 오는 지역의 날씨를 받아오고 
날씨 코드가 비와 관련된 날씨 코드일 때 RainLayer가 잘 나오는지 확인한 사진

**테스트 스크린샷**
<img src="https://github.com/user-attachments/assets/41532301-d17a-45ee-8a1c-f04b34cc3627" width="300"/>



## 이슈
closes #29 
