### PR TITLE
[REFACTOR] .env 환경변수로 카카오 로그인 redirect 하드코딩 제거

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 .env
+.env.production

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -23,17 +23,19 @@ export const useAuth = () => {
   const { mutate: loginWithKakao, isPending: isLoggingIn } = usePostKakaoCode();
 
   // 사용자 정보 query
-  const { isLoading: isLoadingUserInfo, isError: userInfoError } =
-    useUserInfo();
+  const { isLoading: isLoadingUserInfo, isError: userInfoError } = useUserInfo();
 
   /**
    * 카카오 로그인 페이지로 리다이렉트
    */
   const initiateKakaoLogin = () => {
-    window.location.href = `https://kauth.kakao.com/oauth/authorize?
+    const baseUrl = import.meta.env.VITE_APP_BASE_URL;
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?
 response_type=code
 &client_id=8162b95c200bcd82ce88d8c5468f41c5
-&redirect_uri=http://localhost:5173/auth/login/kakao`;
+&redirect_uri=${baseUrl}/auth/login/kakao`;
+
+    window.location.href = kakaoAuthUrl;
   };
 
   /**


### PR DESCRIPTION
## 유형
- 리팩토링

## 설명
- 카카오 로그인 리다이렉트에서 사용되는 하드코딩된 localhost 주소를 .env의 `VITE_APP_BASE_URL` 환경 변수로 대체하여, 개발 및 배포 환경에서 정상 동작하도록 수정
- 기존에는 `window.location.href`에 직접 URL이 들어가 있었으나, `import.meta.env.VITE_APP_BASE_URL`을 통해 동적으로 구성되도록 변경
- `.env`, `.env.production` 환경변수 등록 (git에는 포함이 안 되어 있으므로 슬랙 및 노션 확인)

## 테스트
배포 후 동작 확인 예정

## 이슈
closes #43 
