### PR TITLE
Feature/48 [REFACTOR] canvas 클릭 이벤트 처리

### DIFF
--- a/src/components/scene/SceneLayout.tsx
+++ b/src/components/scene/SceneLayout.tsx
@@ -24,7 +24,6 @@ const CloudBackground = () => {
     </>
   );
 };
-
 export const SceneLayout = ({
   encryptedSceneId,
   children,
@@ -32,20 +31,25 @@ export const SceneLayout = ({
 }: SceneLayoutProps) => {
   return (
     <div className="relative w-screen h-screen overflow-hidden">
-      {/* Canvas를 최상위 레벨로 배치하여 3D 요소 처리 */}
-      <div className="absolute inset-0 z-0">
+      {/* 3D 요소를 위한 전체 화면 Canvas */}
+      <div className="absolute inset-0">
         <Canvas camera={{ fov: 75, position: [0, 0, 5] }}>
           <CloudBackground />
-          {/* 3D 요소들을 위한 구역 */}
           {threeChildren}
         </Canvas>
       </div>
 
-      {/* 2D UI 요소는 Canvas 밖에 배치 */}
-      <div className="relative z-10 flex flex-col h-full justify-between px-[5%] py-[5%]">
-        <ProfileHeader encryptedSceneId={encryptedSceneId} />
-        {/* 일반 2D children */}
-        {children}
+      {/* 2D UI 요소를 위한 투명 오버레이 */}
+      <div className="absolute inset-0 pointer-events-none">
+        <div className="w-full h-full px-[5%] py-[5%] flex flex-col">
+          {/* 상단 헤더 영역 - 포인터 이벤트 활성화 */}
+          <div className="pointer-events-auto">
+            <ProfileHeader encryptedSceneId={encryptedSceneId} />
+          </div>
+
+          {/* 하단 컨텐츠 영역 - children에 직접 pointer-events-auto 클래스 적용 */}
+          <div className="pointer-events-auto">{children}</div>
+        </div>
       </div>
     </div>
   );

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -6,7 +6,6 @@ import { BubbleSelectorBox } from "@/components/message/BubbleSelectorBox";
 import { useAuthStore } from "@/store/authStore";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-
 export const MessagePage = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
@@ -34,15 +33,25 @@ export const MessagePage = () => {
   return (
     <SceneLayout
       encryptedSceneId={encryptedSceneId}
-      // 2D UI 요소를 일반 children으로 전달
+      threeChildren={<BubbleSelectorBox />}
       children={
-        <div className="flex flex-col h-full justify-between mt-[5%]">
-          <MessageInputBox />
-          <ButtonLg isOwner={false} />
+        <div className="h-full w-full pointer-events-none">
+          {/* 메시지 입력 박스 컴포넌트 - 상단에 배치 */}
+          <div className="pointer-events-auto mt-[5%]">
+            <MessageInputBox />
+          </div>
+
+          {/* 버블 남기기 버튼 - 화면 맨 하단에 고정 */}
+          <div className="pointer-events-auto fixed bottom-6 left-0 w-full flex justify-center">
+            <ButtonLg
+              isOwner={false}
+              onClick={() => {
+                console.log("eeee");
+              }}
+            />
+          </div>
         </div>
       }
-      // 3D 객체는 threeChildren으로 전달
-      threeChildren={<BubbleSelectorBox />}
     />
   );
 };


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 버그 수정
- [ ] 리팩토링

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->

# 포인터 이벤트 핵심 정리

React Three Fiber(R3F)와 일반 DOM 요소를 같이 사용할 때 클릭 이벤트 처리의 핵심

1. **기본 원리**: CSS의 `pointer-events` 속성을 사용하여 특정 요소에서 마우스 이벤트를 받을지 또는 통과시킬지 제어합니다.
2. **포인터 이벤트 비활성화**: 
   ```css
   pointer-events: none; /* 또는 Tailwind CSS: pointer-events-none */
   ```
   이 설정은 요소가 마우스 이벤트를 무시하고 해당 이벤트가 "통과"하여 아래 레이어(3D Canvas)로 전달되게 합니다.

3. **포인터 이벤트 활성화**:
   ```css
   pointer-events: auto; /* 또는 Tailwind CSS: pointer-events-auto */
   ```
   이 설정은 요소가 마우스 이벤트를 가로채서 처리하도록 합니다.

4. **계층 구조 설계**:
   - 최상위 2D UI 컨테이너: `pointer-events-none` (기본적으로 모든 이벤트 통과)
   - 개별 UI 요소(버튼, 입력 필드 등): `pointer-events-auto` (필요한 요소만 이벤트 가로채기)

# 핵심 변경사항

선택적 포인터 이벤트 구현:

2D UI 컨테이너에 pointer-events-none 적용하여 기본적으로 클릭 이벤트가 3D 요소로 통과하도록 설정
상호작용이 필요한 UI 요소에만 pointer-events-auto를 적용하여 선택적으로 클릭 이벤트 처리

SceneLayout 구조 개선:

Canvas와 DOM 요소를 명확히 분리하여 렌더링 컨텍스트 충돌 방지
레이어 구조 최적화로 3D 객체와 2D UI의 독립적 상호작용 보장

버튼 위치 조정:

fixed 포지셔닝으로 "버블 남기기" 버튼을 화면 맨 하단에 배치
레이아웃 일관성과 사용자 경험 개선