### PR TITLE
[FEAT] Message post api 연동

### DIFF
--- a/src/components/message/BubbleSelectorBox.tsx
+++ b/src/components/message/BubbleSelectorBox.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Vector3 } from "three";
 import {
   FlowerDrop,
@@ -8,9 +7,15 @@ import {
   WaterDrop,
 } from "./WaterDropt";
 
-export const BubbleSelectorBox = () => {
-  const [selectedBubble, setSelectedBubble] = useState<number | null>(null);
+interface BubbleSelectorBoxProps {
+  selectedBubble: number | null;
+  onSelectBubble: (index: number | null) => void;
+}
 
+export const BubbleSelectorBox = ({
+  selectedBubble,
+  onSelectBubble,
+}: BubbleSelectorBoxProps) => {
   const bubblePositions = [
     new Vector3(-1.4, -2.5, 0), // far left
     new Vector3(-0.7, -2.5, 0), // left
@@ -29,10 +34,12 @@ export const BubbleSelectorBox = () => {
   ];
 
   const handleBubbleClick = (index: number) => {
+    // 같은 버블을 다시 클릭하면 선택 해제
     if (selectedBubble === index) {
-      setSelectedBubble(null); // deselect
+      onSelectBubble(null);
     } else {
-      setSelectedBubble(index); // select new one
+      // 새로운 버블 선택
+      onSelectBubble(index);
     }
   };
 

--- a/src/components/message/MessageInputBox.tsx
+++ b/src/components/message/MessageInputBox.tsx
@@ -2,17 +2,33 @@ import { Card, CardContent } from "../ui/card";
 import { Input } from "../ui/input";
 import { Textarea } from "../ui/textarea";
 
-export const MessageInputBox = () => {
+interface MessageInputBoxProps {
+  content: string;
+  nickName: string;
+  onContentChange: (value: string) => void;
+  onNickNameChange: (value: string) => void;
+}
+
+export const MessageInputBox = ({
+  content,
+  nickName,
+  onContentChange,
+  onNickNameChange,
+}: MessageInputBoxProps) => {
   return (
     <Card className="w-full rounded-3xl bg-gray-100 border-none shadow-lg">
       <CardContent className="flex flex-col gap-3">
         <Textarea
           className="min-h-[5rem] w-full border border-gray-300 text-gray-700 shadow-md focus:shadow-xl"
           placeholder="무슨 이야기를 남겨볼까요?"
+          value={content}
+          onChange={(e) => onContentChange(e.target.value)}
         />
         <Input
           className="w-[30%] self-end border border-gray-300 text-gray-700 shadow-md focus:shadow-xl"
           placeholder="From..."
+          value={nickName}
+          onChange={(e) => onNickNameChange(e.target.value)}
         />
       </CardContent>
     </Card>

--- a/src/components/scene/ButtonLg.tsx
+++ b/src/components/scene/ButtonLg.tsx
@@ -3,15 +3,18 @@ import { Button } from "@/components/ui/button";
 interface ButtonLgProps {
   isOwner: boolean;
   onClick?: () => void;
+  disabled?: boolean;
 }
 
-export function ButtonLg({ isOwner, onClick }: ButtonLgProps) {
+export function ButtonLg({ isOwner, onClick, disabled }: ButtonLgProps) {
   const BUTTON_TEXT = isOwner ? "🫧 버블 공유하기" : "🫧 버블 남기기";
 
   return (
     <Button
+      disabled={disabled}
       onClick={onClick}
-      className="bg-gray-50 font-jua rounded-2xl mb-[10%] h-[3rem] text-xl shadow-lg cursor-pointer">
+      className="bg-gray-50 font-jua rounded-2xl mb-[10%] h-[3rem] text-xl shadow-lg cursor-pointer"
+    >
       {BUTTON_TEXT}
     </Button>
   );

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -21,6 +21,7 @@ export const MessagePage = () => {
   // message input 데이터
   const [inputContent, setInputContent] = useState("");
   const [inputNickName, setInputNickName] = useState("");
+  const [inputModelId, setInputModelId] = useState<number | null>(null);
 
   useEffect(() => {
     if (
@@ -45,11 +46,18 @@ export const MessagePage = () => {
     setInputNickName(value);
   };
 
+  // 모델 ID 변경 핸들러
+  const handleModelChange = (index: number | null) => {
+    console.log("Selected bubble index:", index);
+    setInputModelId(index);
+  };
+
   // 버튼 클릭 핸들러
   const handleSubmit = () => {
     console.log("메시지 제출:", {
       content: inputContent,
       nickName: inputNickName,
+      modelId: inputModelId,
       encryptedSceneId,
     });
     // 여기에 API 호출 등의 제출 로직 추가
@@ -60,7 +68,12 @@ export const MessagePage = () => {
   return (
     <SceneLayout
       encryptedSceneId={encryptedSceneId}
-      threeChildren={<BubbleSelectorBox />}
+      threeChildren={
+        <BubbleSelectorBox
+          selectedBubble={inputModelId}
+          onSelectBubble={handleModelChange}
+        />
+      }
       children={
         <div className="h-full w-full pointer-events-none">
           {/* 메시지 입력 박스 컴포넌트 - 상단에 배치 */}

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -24,6 +24,8 @@ export const MessagePage = () => {
   const [inputNickName, setInputNickName] = useState("");
   const [inputModelId, setInputModelId] = useState<number | null>(null);
 
+  const [isSubmitAble, setIsSubmitAble] = useState(false);
+
   // message 추가 api 연동
   const { mutate: submitMessage } = usePostMessage();
 
@@ -37,6 +39,19 @@ export const MessagePage = () => {
       setIsOwner(true);
     }
   }, [isSuccess, data, isAuthenticated, user]);
+
+  // message 유효성 검사에 따른 버튼 활성화
+  useEffect(() => {
+    if (
+      inputContent.length > 0 &&
+      inputNickName.length > 0 &&
+      inputModelId !== null
+    ) {
+      setIsSubmitAble(true);
+    } else {
+      setIsSubmitAble(false);
+    }
+  }, [inputContent, inputNickName, inputModelId]);
 
   // 메시지 내용 변경 핸들러
   const handleContentChange = (value: string) => {
@@ -59,7 +74,7 @@ export const MessagePage = () => {
     if (!encryptedSceneId || inputModelId == null) {
       return;
     }
-    // 여기에 API 호출 등의 제출 로직 추가
+    // message post api call
     submitMessage({
       sceneId: encryptedSceneId,
       nickname: inputNickName,
@@ -93,7 +108,11 @@ export const MessagePage = () => {
 
           {/* 버블 남기기 버튼 - 화면 맨 하단에 고정 */}
           <div className="pointer-events-auto fixed bottom-6 left-0 w-full flex justify-center">
-            <ButtonLg isOwner={false} onClick={handleSubmit} />
+            <ButtonLg
+              isOwner={false}
+              onClick={handleSubmit}
+              disabled={!isSubmitAble}
+            />
           </div>
         </div>
       }

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -6,6 +6,7 @@ import { BubbleSelectorBox } from "@/components/message/BubbleSelectorBox";
 import { useAuthStore } from "@/store/authStore";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { usePostMessage } from "@/apis/api/post/usePostMessage";
 
 export const MessagePage = () => {
   const location = useLocation();
@@ -23,6 +24,9 @@ export const MessagePage = () => {
   const [inputNickName, setInputNickName] = useState("");
   const [inputModelId, setInputModelId] = useState<number | null>(null);
 
+  // message 추가 api 연동
+  const { mutate: submitMessage } = usePostMessage();
+
   useEffect(() => {
     if (
       isAuthenticated &&
@@ -36,31 +40,32 @@ export const MessagePage = () => {
 
   // 메시지 내용 변경 핸들러
   const handleContentChange = (value: string) => {
-    console.log(value);
     setInputContent(value);
   };
 
   // 닉네임 변경 핸들러
   const handleNickNameChange = (value: string) => {
-    console.log(value);
     setInputNickName(value);
   };
 
   // 모델 ID 변경 핸들러
   const handleModelChange = (index: number | null) => {
-    console.log("Selected bubble index:", index);
     setInputModelId(index);
   };
 
   // 버튼 클릭 핸들러
   const handleSubmit = () => {
-    console.log("메시지 제출:", {
-      content: inputContent,
-      nickName: inputNickName,
-      modelId: inputModelId,
-      encryptedSceneId,
-    });
+    // 타입 확인
+    if (!encryptedSceneId || inputModelId == null) {
+      return;
+    }
     // 여기에 API 호출 등의 제출 로직 추가
+    submitMessage({
+      sceneId: encryptedSceneId,
+      nickname: inputNickName,
+      modelId: String(inputModelId + 1),
+      content: inputContent,
+    });
   };
 
   if (!encryptedSceneId || isOwner) return null;

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -6,6 +6,7 @@ import { BubbleSelectorBox } from "@/components/message/BubbleSelectorBox";
 import { useAuthStore } from "@/store/authStore";
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+
 export const MessagePage = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
@@ -16,6 +17,10 @@ export const MessagePage = () => {
 
   // 게시판 주인 여부 확인
   const [isOwner, setIsOwner] = useState(false);
+
+  // message input 데이터
+  const [inputContent, setInputContent] = useState("");
+  const [inputNickName, setInputNickName] = useState("");
 
   useEffect(() => {
     if (
@@ -28,6 +33,28 @@ export const MessagePage = () => {
     }
   }, [isSuccess, data, isAuthenticated, user]);
 
+  // 메시지 내용 변경 핸들러
+  const handleContentChange = (value: string) => {
+    console.log(value);
+    setInputContent(value);
+  };
+
+  // 닉네임 변경 핸들러
+  const handleNickNameChange = (value: string) => {
+    console.log(value);
+    setInputNickName(value);
+  };
+
+  // 버튼 클릭 핸들러
+  const handleSubmit = () => {
+    console.log("메시지 제출:", {
+      content: inputContent,
+      nickName: inputNickName,
+      encryptedSceneId,
+    });
+    // 여기에 API 호출 등의 제출 로직 추가
+  };
+
   if (!encryptedSceneId || isOwner) return null;
 
   return (
@@ -38,17 +65,17 @@ export const MessagePage = () => {
         <div className="h-full w-full pointer-events-none">
           {/* 메시지 입력 박스 컴포넌트 - 상단에 배치 */}
           <div className="pointer-events-auto mt-[5%]">
-            <MessageInputBox />
+            <MessageInputBox
+              content={inputContent}
+              nickName={inputNickName}
+              onContentChange={handleContentChange}
+              onNickNameChange={handleNickNameChange}
+            />
           </div>
 
           {/* 버블 남기기 버튼 - 화면 맨 하단에 고정 */}
           <div className="pointer-events-auto fixed bottom-6 left-0 w-full flex justify-center">
-            <ButtonLg
-              isOwner={false}
-              onClick={() => {
-                console.log("eeee");
-              }}
-            />
+            <ButtonLg isOwner={false} onClick={handleSubmit} />
           </div>
         </div>
       }

--- a/src/types/message.types.ts
+++ b/src/types/message.types.ts
@@ -22,4 +22,5 @@ export interface MessagePostRequest {
   sceneId: string;
   nickname: string;
   content: string;
+  modelId: string;
 }


### PR DESCRIPTION
## 유형
- 기능추가

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->

## 테스트
- message 페이지에서 (http://localhost:5173/message?id=cFJqN0RTSzkwdW9RaXJNeU40ZFIvQTVsYjZlY1VSQi9yd2x3OG82SVU4SVdKaHJYbzF0SDRPQ3RFN3c2eHA5MQ==) 버블을 남기고
- 컨텐츠, 닉네임, 모델 선택을 모두 해야만 하단 버블 버튼이 활성화됨을 확인
![image](https://github.com/user-attachments/assets/cb07c582-737f-40f0-b791-fa9e0babc615)
- 버블 남기기 버튼 클릭 후 swagger에서 sceneId로 메세지를 조회해 message post성공여부 확인
![image](https://github.com/user-attachments/assets/7c8e70a0-ddb4-4da5-b294-8b229fd2f173)

## 이슈
#56 
