### PR TITLE
[FEAT] scene 메시지 조회 및 메시지 버블 렌더링

### DIFF
--- a/src/components/scene/SceneMessages.tsx
+++ b/src/components/scene/SceneMessages.tsx
@@ -1,0 +1,40 @@
+import { FlowerDrop, HeartDrop, StarDrop, TeardropShape, WaterDrop } from "../message/WaterDropt";
+import { useGetMessages } from "@/apis/api/get/useGetMessages";
+import { BubbleComponentType } from "@/types/bubble.types";
+import { MessageResponse, ModelId } from "@/types/message.types";
+
+const modelComponents: Record<ModelId, BubbleComponentType> = {
+  "1": WaterDrop,
+  "2": HeartDrop,
+  "3": TeardropShape,
+  "4": StarDrop,
+  "5": FlowerDrop,
+};
+
+export const SceneMessages = ({ encryptedSceneId }: { encryptedSceneId: string }) => {
+  const { data: messageData, isSuccess: messagesLoaded } = useGetMessages(encryptedSceneId);
+
+  if (!messagesLoaded) return null;
+
+  return (
+    <>
+      {messageData.data?.map((msg: MessageResponse) => {
+        const Drop = modelComponents[msg.modelId];
+
+        const x = Math.random() * 3 - 1.5;
+        const y = Math.random() * 2 + 1.5;
+        const z = Math.random() - 0.5;
+
+        const handleBubbleClick = (msg: MessageResponse) => {
+          console.log(`Bubble clicked: ${msg.messageId}`);
+        };
+
+        return (
+          <group key={msg.messageId} position={[x, y, z]}>
+            <Drop onClick={() => handleBubbleClick(msg)} position={[0, 0, 0]} />
+          </group>
+        );
+      })}
+    </>
+  );
+};

--- a/src/pages/ScenePage.tsx
+++ b/src/pages/ScenePage.tsx
@@ -5,6 +5,7 @@ import { ButtonLg } from "@/components/scene/ButtonLg";
 import { useAuthStore } from "@/store/authStore";
 import { SceneLayout } from "@/components/scene/SceneLayout";
 import { useWebShare } from "@/hooks/useWebShare";
+import { SceneMessages } from "@/components/scene/SceneMessages";
 
 export const ScenePage = () => {
   const { encryptedSceneId } = useParams<{ encryptedSceneId: string }>();
@@ -34,13 +35,13 @@ export const ScenePage = () => {
       encryptedSceneId={encryptedSceneId}
       // 2D UI 요소 (ButtonLg)를 일반 children으로 전달
       children={
-        <div className="flex flex-col h-full justify-end">
+        <div className="pointer-events-auto fixed bottom-6 left-0 w-full flex justify-center">
           <ButtonLg isOwner={isOwner} onClick={isOwner ? shareToLink : handleLeaveMessage} />
         </div>
       }
       // 현재 3D 객체가 필요 없다면 threeChildren은 생략 가능
       // 필요시 3D 객체 추가 가능
-      threeChildren={null}
+      threeChildren={<SceneMessages encryptedSceneId={encryptedSceneId} />}
     />
   );
 };

--- a/src/types/message.types.ts
+++ b/src/types/message.types.ts
@@ -1,10 +1,13 @@
 import { ApiResponse } from "@/types/api.types.ts";
 
+export type ModelId = "1" | "2" | "3" | "4" | "5";
+
 export interface MessageResponse {
   messageId: number;
   nickname: string;
   content: string;
   createdAt: string;
+  modelId: ModelId;
 }
 
 export type MessageGetResponse = ApiResponse<MessageResponse[]>; // 실제 응답 값


### PR DESCRIPTION
## 유형
- 기능 추가

## 설명
<img src="https://github.com/user-attachments/assets/a3a235fc-600e-4d14-8b22-2fe76887bb5d" width="300px" />

- `useGetMessages(encryptedSceneId)`를 통해 메시지 수신 확인
- modelId에 맞게 3D 물방울 렌더링
- scene page에서 메시지 확인 및 버블 클릭되는지 확인


## 이슈
closes #58
