### PR TITLE
[FEAT] modal animation

### DIFF
--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -16,6 +16,12 @@ export const Modal = ({ modalKey, onSave }: ModalProps) => {
   const { initiateKakaoLogin } = useAuth();
 
   const isModalOpen = isOpen(modalKey);
+  const handleCloseWithAnimation = () => {
+    setAnimateIn(false);
+    setTimeout(() => {
+      closeModal(modalKey);
+    }, 700);
+  };
 
   useEffect(() => {
     if (isModalOpen) {
@@ -32,7 +38,7 @@ export const Modal = ({ modalKey, onSave }: ModalProps) => {
       {modalKey === "themeModal" && (
         <ModalThemeSelector
           animateIn={animateIn}
-          onClose={() => closeModal(modalKey)}
+          onClose={handleCloseWithAnimation}
           onSave={onSave}
         />
       )}
@@ -40,7 +46,7 @@ export const Modal = ({ modalKey, onSave }: ModalProps) => {
       {modalKey === "loginModal" && (
         <ModalLoginPrompt
           animateIn={animateIn}
-          onClose={() => closeModal(modalKey)}
+          onClose={handleCloseWithAnimation}
           onLogin={initiateKakaoLogin}
         />
       )}


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
transition 시간과 setTimeout 딜레이를 맞춰 부드러운 UX 

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
- Modal.tsx에 handleCloseWithAnimation() 함수 추가
- animateIn = false → translateY + opacity 애니메이션 시작
- setTimeout(700ms) 후 closeModal 실행
- ModalThemeSelector에서 닫힘 애니메이션 적용되도록 연결

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
<img src="https://github.com/user-attachments/assets/c6d69efa-2b44-4b30-842d-9b16d2fe1487" width="200" height="350"/>

## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->
closes #74
