### PR TITLE
[FEAT] 고정 위치 수정 및 FloatingMessageBubble 관련 에러 수정

### DIFF
--- a/src/components/message/FloatingMessageBubble.tsx
+++ b/src/components/message/FloatingMessageBubble.tsx
@@ -21,7 +21,7 @@ export const FloatingMessageBubble = ({
   });
 
   return (
-    <group ref={groupRef} position={position} scale={[scale, scale, scale]} onClick={onClick}>
+    <group ref={groupRef} position={position} scale={[scale, scale, scale]}>
       <BubbleComponent
         onClick={onClick}
         minVibration={true}

--- a/src/components/scene/SceneMessages.tsx
+++ b/src/components/scene/SceneMessages.tsx
@@ -13,16 +13,16 @@ const modelComponents: Record<ModelId, BubbleComponentType> = {
 };
 
 const fixedPositions: [number, number, number][] = [
-  [-1, 2.5, 0],
-  [1.2, 2, 0],
-  [-0.4, 0.7, 0],
-  [0.4, 0.4, 0],
-  [0, 0.1, 0],
-  [-0.5, -0.2, 0],
-  [0.5, -0.4, 0],
-  [-0.4, -0.6, 0],
-  [0.4, -0.75, 0],
-  [0, -2, 0],
+  [-1.0, 2.4, 0],
+  [-0.2, 1.5, 0],
+  [1.0, 2.2, 0],
+  [-0.9, 0.5, 0],
+  [0.8, 0.3, 0],
+  [-0.1, -0.4, 0],
+  [0.5, -1.4, 0],
+  [1.0, -2.4, 0],
+  [-0.6, -2.3, 0],
+  [-1.2, -1.5, 0],
 ];
 
 export const SceneMessages = ({
@@ -38,7 +38,7 @@ export const SceneMessages = ({
 
   return (
     <>
-      {messageData.data?.map((msg: MessageResponse, index: number) => {
+      {messageData.data?.slice(0, 10).map((msg: MessageResponse, index: number) => {
         const BubbleComponent = modelComponents[msg.modelId];
         const position = fixedPositions[index];
 


### PR DESCRIPTION
## 유형
- 기능 추가


## 설명
- 메시지 버블 고정 위치 수정 (화면에 적절히 퍼지게)
- `FloatingMessageBubble` 관련 에러 수정
    - 고정 위치 배열이 10개라 `messageData`에 slice(0,10) 추가해서 수정
- 메시지 버블 클릭하면 onClick 두 번 되는 에러 수정


## 이슈
closes #82 
