### PR TITLE
[FEAT] 비로그인 메세지 작성 후 모달 처리

### DIFF
--- a/src/components/common/ConfirmBubbleModal.tsx
+++ b/src/components/common/ConfirmBubbleModal.tsx
@@ -39,7 +39,7 @@ export const MessageConfirmModal: React.FC<MessageConfirmModalProps> = ({
       {
         onSuccess: () => {
           onClose();
-          navigate(-1);
+          navigate(`/${sceneId}?sentBubble=true`, { replace: true });
         },
         onError: (err: unknown) => {
           const msg = err instanceof Error ? err.message : "알 수 없는 오류";

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -6,6 +6,7 @@ import { MessageConfirmModal } from "./ConfirmBubbleModal.tsx";
 import { useModalStore } from "@/store/modalstore";
 import { EnvironmentPreset } from "@/lib/constants";
 import { useAuth } from "@/hooks/useAuth";
+import { ModalShareIntro } from "@/components/common/ModalShareIntro.tsx";
 
 interface ModalProps {
   modalKey: string;
@@ -15,6 +16,8 @@ interface ModalProps {
   nickname?: string;
   modelId?: number;
   content?: string;
+  onLogin?: () => void;
+  onConfirm?: () => void;
 }
 
 export const Modal: React.FC<ModalProps> = ({
@@ -24,6 +27,8 @@ export const Modal: React.FC<ModalProps> = ({
   nickname,
   modelId,
   content,
+  onLogin,
+  onConfirm,
 }) => {
   const [animateIn, setAnimateIn] = useState(false);
   const { isOpen, closeModal } = useModalStore();
@@ -74,6 +79,22 @@ export const Modal: React.FC<ModalProps> = ({
             content={content}
           />
         )}
+
+      {modalKey === "shareIntroModal" && (
+        <ModalShareIntro
+          animateIn={animateIn}
+          onClose={closeWithAnim}
+          onConfirm={onConfirm}
+        />
+      )}
+
+      {modalKey === "loginPrompt" && (
+        <ModalLoginPrompt
+          animateIn={animateIn}
+          onClose={closeWithAnim}
+          onLogin={onLogin}
+        />
+      )}
     </>
   );
 };

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -5,7 +5,7 @@ import { ModalLoginPrompt } from "./ModalLoginPrompt";
 import { MessageConfirmModal } from "./ConfirmBubbleModal.tsx";
 import { useModalStore } from "@/store/modalstore";
 import { EnvironmentPreset } from "@/lib/constants";
-import { useAuth } from "@/hooks/useAuth";
+// import { useAuth } from "@/hooks/useAuth";
 import { ModalShareIntro } from "@/components/common/ModalShareIntro.tsx";
 
 interface ModalProps {
@@ -16,7 +16,6 @@ interface ModalProps {
   nickname?: string;
   modelId?: number;
   content?: string;
-  onLogin?: () => void;
   onConfirm?: () => void;
 }
 
@@ -27,12 +26,11 @@ export const Modal: React.FC<ModalProps> = ({
   nickname,
   modelId,
   content,
-  onLogin,
   onConfirm,
 }) => {
   const [animateIn, setAnimateIn] = useState(false);
   const { isOpen, closeModal } = useModalStore();
-  const { initiateKakaoLogin } = useAuth();
+  // const { initiateKakaoLogin } = useAuth();
 
   const open = isOpen(modalKey);
   useEffect(() => {
@@ -58,11 +56,7 @@ export const Modal: React.FC<ModalProps> = ({
       )}
 
       {modalKey === "loginModal" && (
-        <ModalLoginPrompt
-          animateIn={animateIn}
-          onClose={closeWithAnim}
-          onLogin={initiateKakaoLogin}
-        />
+        <ModalLoginPrompt animateIn={animateIn} onClose={closeWithAnim} />
       )}
 
       {modalKey === "confirmBubble" &&
@@ -85,14 +79,6 @@ export const Modal: React.FC<ModalProps> = ({
           animateIn={animateIn}
           onClose={closeWithAnim}
           onConfirm={onConfirm}
-        />
-      )}
-
-      {modalKey === "loginPrompt" && (
-        <ModalLoginPrompt
-          animateIn={animateIn}
-          onClose={closeWithAnim}
-          onLogin={onLogin}
         />
       )}
     </>

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -5,7 +5,7 @@ import { ModalLoginPrompt } from "./ModalLoginPrompt";
 import { MessageConfirmModal } from "./ConfirmBubbleModal.tsx";
 import { useModalStore } from "@/store/modalstore";
 import { EnvironmentPreset } from "@/lib/constants";
-// import { useAuth } from "@/hooks/useAuth";
+import { useAuth } from "@/hooks/useAuth";
 import { ModalShareIntro } from "@/components/common/ModalShareIntro.tsx";
 
 interface ModalProps {
@@ -30,7 +30,7 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const [animateIn, setAnimateIn] = useState(false);
   const { isOpen, closeModal } = useModalStore();
-  // const { initiateKakaoLogin } = useAuth();
+  const { initiateKakaoLogin } = useAuth();
 
   const open = isOpen(modalKey);
   useEffect(() => {
@@ -56,7 +56,11 @@ export const Modal: React.FC<ModalProps> = ({
       )}
 
       {modalKey === "loginModal" && (
-        <ModalLoginPrompt animateIn={animateIn} onClose={closeWithAnim} />
+        <ModalLoginPrompt
+          animateIn={animateIn}
+          onClose={closeWithAnim}
+          onLogin={initiateKakaoLogin}
+        />
       )}
 
       {modalKey === "confirmBubble" &&

--- a/src/components/common/ModalLoginPrompt.tsx
+++ b/src/components/common/ModalLoginPrompt.tsx
@@ -4,10 +4,22 @@ import fingerAnimation from "@/assets/lottie/finger.json";
 interface ModalLoginPromptProps {
   onClose: () => void;
   animateIn: boolean;
-  onLogin: () => void;
 }
 
-export const ModalLoginPrompt = ({ onClose, animateIn, onLogin }: ModalLoginPromptProps) => {
+export const ModalLoginPrompt = ({
+  onClose,
+  animateIn,
+}: ModalLoginPromptProps) => {
+  const handleKakaoLogin = () => {
+    // Vite 환경 변수 접근
+    const kakaoUrl = import.meta.env.VITE_KAKAO_LOGIN_URL!;
+    console.log("redirect to:", kakaoUrl);
+    if (!kakaoUrl) {
+      console.error("VITE_KAKAO_LOGIN_URL 이 정의되지 않았습니다!");
+      return;
+    }
+    window.location.assign(kakaoUrl);
+  };
   return (
     <div className="fixed inset-0 bg-black/40 z-50" onClick={onClose}>
       <div
@@ -15,19 +27,26 @@ export const ModalLoginPrompt = ({ onClose, animateIn, onLogin }: ModalLoginProm
           top-[120px] transition-all duration-700
           ${animateIn ? "translate-y-0 opacity-100" : "translate-y-10 opacity-0"}
         `}
-        onClick={(e) => e.stopPropagation()}>
+        onClick={(e) => e.stopPropagation()}
+      >
         <div className="bg-white rounded-3xl p-6 shadow-xl max-w-[330px]">
           <div className="flex items-center justify-center gap-4">
-            <Lottie animationData={fingerAnimation} style={{ width: 100, height: 100 }} />
+            <Lottie
+              animationData={fingerAnimation}
+              style={{ width: 100, height: 100 }}
+            />
             <div className="text-left flex flex-col items-center pr-2 space-y-2">
-              <p className="text-[#575757] text-sm whitespace-nowrap">나만의 페이지를 만들게요</p>
+              <p className="text-[#575757] text-sm whitespace-nowrap">
+                나만의 페이지를 만들게요
+              </p>
               <h2 className="text-lg font-semibold leading-snug whitespace-nowrap">
                 우선 로그인 해주세요
               </h2>
               <button
-                onClick={onLogin}
+                onClick={handleKakaoLogin}
                 className="rounded-full px-6 py-2 text-black font-semibold mt-1 hover:opacity-90 shadow cursor-pointer"
-                style={{ backgroundColor: "#FEE500" }}>
+                style={{ backgroundColor: "#FEE500" }}
+              >
                 카카오로 로그인
               </button>
             </div>

--- a/src/components/common/ModalLoginPrompt.tsx
+++ b/src/components/common/ModalLoginPrompt.tsx
@@ -4,22 +4,14 @@ import fingerAnimation from "@/assets/lottie/finger.json";
 interface ModalLoginPromptProps {
   onClose: () => void;
   animateIn: boolean;
+  onLogin?: () => void;
 }
 
 export const ModalLoginPrompt = ({
   onClose,
   animateIn,
+  onLogin,
 }: ModalLoginPromptProps) => {
-  const handleKakaoLogin = () => {
-    // Vite 환경 변수 접근
-    const kakaoUrl = import.meta.env.VITE_KAKAO_LOGIN_URL!;
-    console.log("redirect to:", kakaoUrl);
-    if (!kakaoUrl) {
-      console.error("VITE_KAKAO_LOGIN_URL 이 정의되지 않았습니다!");
-      return;
-    }
-    window.location.assign(kakaoUrl);
-  };
   return (
     <div className="fixed inset-0 bg-black/40 z-50" onClick={onClose}>
       <div
@@ -43,7 +35,7 @@ export const ModalLoginPrompt = ({
                 우선 로그인 해주세요
               </h2>
               <button
-                onClick={handleKakaoLogin}
+                onClick={onLogin}
                 className="rounded-full px-6 py-2 text-black font-semibold mt-1 hover:opacity-90 shadow cursor-pointer"
                 style={{ backgroundColor: "#FEE500" }}
               >

--- a/src/components/common/ModalShareIntro.tsx
+++ b/src/components/common/ModalShareIntro.tsx
@@ -7,9 +7,14 @@ import { useParams } from "react-router-dom";
 interface ModalShareIntroProps {
   onClose: () => void;
   animateIn: boolean;
+  onConfirm?: () => void;
 }
 
-export const ModalShareIntro = ({ onClose, animateIn }: ModalShareIntroProps) => {
+export const ModalShareIntro = ({
+  onClose,
+  animateIn,
+  onConfirm,
+}: ModalShareIntroProps) => {
   const { encryptedSceneId } = useParams<{ encryptedSceneId: string }>();
   const { data, isSuccess } = useGetEncryptedSceneIds(encryptedSceneId || "");
   const [nickName, setNickName] = useState("사용자");
@@ -30,9 +35,14 @@ export const ModalShareIntro = ({ onClose, animateIn }: ModalShareIntroProps) =>
       >
         <div className="bg-white rounded-3xl p-6 shadow-xl w-[330px]">
           <div className="flex items-center justify-center gap-4">
-            <Lottie animationData={clapAnimation} style={{ width: 80, height: 80 }} />
+            <Lottie
+              animationData={clapAnimation}
+              style={{ width: 80, height: 80 }}
+            />
             <div className="text-left">
-              <p className="text-[#575757] text-sm mb-2">‘{nickName}’님께 버블을 전달했어요</p>
+              <p className="text-[#575757] text-sm mb-2">
+                ‘{nickName}’님께 버블을 전달했어요
+              </p>
               <h2 className="text-lg font-semibold leading-snug">
                 나만의 페이지를 만들어
                 <br />
@@ -51,6 +61,7 @@ export const ModalShareIntro = ({ onClose, animateIn }: ModalShareIntroProps) =>
             <button
               className="rounded-full px-6 py-2 text-blue-700 font-semibold hover:opacity-90 shadow cursor-pointer"
               style={{ backgroundColor: "#9DEEFB" }}
+              onClick={onConfirm}
             >
               Yes
             </button>

--- a/src/components/message/FloatingMessageBubble.tsx
+++ b/src/components/message/FloatingMessageBubble.tsx
@@ -1,5 +1,5 @@
 import { FloatingMessageBubbleProps } from "@/types/bubble.types";
-import { useFrame } from "@react-three/fiber";
+// import { useFrame } from "@react-three/fiber";
 import { useRef } from "react";
 import { Group } from "three";
 
@@ -13,15 +13,20 @@ export const FloatingMessageBubble = ({
 }: FloatingMessageBubbleProps) => {
   const groupRef = useRef<Group>(null);
 
-  useFrame(({ clock }) => {
-    const t = clock.getElapsedTime();
-    if (groupRef.current) {
-      groupRef.current.position.y = position[1] + Math.sin(t + position[0]) * 0.05;
-    }
-  });
+  // useFrame(({ clock }) => {
+  //   const t = clock.getElapsedTime();
+  //   if (groupRef.current) {
+  //     groupRef.current.position.y = position[1] + Math.sin(t + position[0]) * 0.05;
+  //   }
+  // });
 
   return (
-    <group ref={groupRef} position={position} scale={[scale, scale, scale]} onClick={onClick}>
+    <group
+      ref={groupRef}
+      position={position}
+      scale={[scale, scale, scale]}
+      onClick={onClick}
+    >
       <BubbleComponent
         onClick={onClick}
         minVibration={true}

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -39,7 +39,7 @@ export const MessagePage: React.FC = () => {
     setIsSubmitAble(
       inputContent.trim().length > 0 &&
         inputNickName.trim().length > 0 &&
-        inputModelId !== null
+        inputModelId !== null,
     );
   }, [inputContent, inputNickName, inputModelId]);
 
@@ -47,7 +47,7 @@ export const MessagePage: React.FC = () => {
     openModal("confirmBubble");
   };
 
-  if (isOwner || !isAuthenticated || !isSuccess) return null;
+  if (isOwner || !isSuccess) return null;
 
   return (
     <>

--- a/src/pages/ScenePage.tsx
+++ b/src/pages/ScenePage.tsx
@@ -75,12 +75,7 @@ export const ScenePage = () => {
 
   const handleShareIntroConfirm = () => {
     closeModal("shareIntroModal");
-    openModal("loginPrompt");
-  };
-
-  const handleKakaoLogin = () => {
-    // .env 에 REACT_APP_KAKAO_LOGIN_URL 로 정의한 카카오 OAuth URL 로 리다이렉트
-    window.location.href = process.env.REACT_APP_KAKAO_LOGIN_URL!;
+    openModal("loginModal");
   };
 
   return (
@@ -95,7 +90,7 @@ export const ScenePage = () => {
               modalKey="shareIntroModal"
               onConfirm={handleShareIntroConfirm}
             />
-            <Modal modalKey="loginPrompt" onLogin={handleKakaoLogin} />
+            <Modal modalKey="loginModal" />
 
             {isOwner && (
               <Button onClick={handleOpenThemeModal}>


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
각자 로컬 환경에서 테스팅 요청

비로그인 상태일 때 상대방 scene에 버블 메시지 남겼을 때의 모달 알림 처리

1. 상대방에게 버블 메시지 보내기 성공시 -> scene 페이지로 돌아가기 navigate(url/?sentBubble=true);
2. 돌아가고 만약 비로그인 사용자면 (파라미터로 조건 처리) 나만의 scene을 만들까요? 모달 알림 ( ModalShareIntro)
3. 확인 버튼 터치 후 우선 로그인 모달 처리 (ModalLoginPrompt ) 
4. 실제 카카오 로그인 url로 이동

## .env 설정 추가 슬랙 아카이브 참고

## 스크린샷
![image](https://github.com/user-attachments/assets/ccc84ce7-7670-4a1e-bb5d-290f9bb9c55b)
![image](https://github.com/user-attachments/assets/bcbc4156-aee6-445b-aefa-2c02532c34c6)


## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->
closes #80 
