### PR TITLE
Bug/93 mobile UI 전역 css 및 테일윈드 뷰포트 계산 커스텀 프로퍼티 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>raindrop</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">    <title>raindrop</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { BrowserRouter } from "react-router-dom";
@@ -16,6 +16,20 @@ const queryClient = new QueryClient({
 });
 
 const App: React.FC = () => {
+  useEffect(() => {
+    const setVh = () => {
+      document.documentElement.style.setProperty(
+        "--vh",
+        `${window.innerHeight * 0.01}px`,
+      );
+    };
+    // 초기 호출
+    setVh();
+    // 리사이즈 때마다 호출
+    window.addEventListener("resize", setVh);
+    return () => window.removeEventListener("resize", setVh);
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -11,7 +11,7 @@ import { useAuthStore } from "@/store/authStore";
 import { logout } from "@/utils/auth";
 
 /** API 엔드포인트 기본 URL */
-const BE_URL = "https://raindrop-back.onrender.com/api";
+const BE_URL = "/api";
 // const BE_URL = "http://localhost:8080/api";
 
 /**

--- a/src/components/message/AnimatedBubble.tsx
+++ b/src/components/message/AnimatedBubble.tsx
@@ -56,8 +56,8 @@ export const AnimatedBubble = ({
       tl.fromTo(
         groupRef.current.position,
         { x: currentX, y: currentY, z: currentZ },
-        { x: 0, y: -0.5, z: 0 },
-        0 // 시작 시간 (동시 시작)
+        { x: 0, y: -0.9, z: 0 },
+        0, // 시작 시간 (동시 시작)
       );
 
       // 크기 애니메이션 추가
@@ -65,7 +65,7 @@ export const AnimatedBubble = ({
         groupRef.current.scale,
         { x: currentScaleX, y: currentScaleY, z: currentScaleZ },
         { x: 5.6, y: 5.6, z: 5.6 },
-        0 // 시작 시간 (동시 시작)
+        0, // 시작 시간 (동시 시작)
       );
     } else {
       // 선택 해제 시 현재 상태에서 원래 위치로 부드럽게 전환
@@ -90,12 +90,12 @@ export const AnimatedBubble = ({
               groupRef.current.position.set(
                 originalPosition.x,
                 originalPosition.y,
-                originalPosition.z
+                originalPosition.z,
               );
             }
           },
         },
-        0 // 시작 시간 (동시 시작)
+        0, // 시작 시간 (동시 시작)
       );
 
       // 호버 상태와 관계없이 항상 1로 설정 (크기 두 번 변하는 버그 수정)
@@ -119,7 +119,7 @@ export const AnimatedBubble = ({
             }
           },
         },
-        0 // 시작 시간 (동시 시작)
+        0, // 시작 시간 (동시 시작)
       );
     }
 

--- a/src/components/scene/SceneLayout.tsx
+++ b/src/components/scene/SceneLayout.tsx
@@ -32,7 +32,7 @@ export const SceneLayout = ({
 }: SceneLayoutProps) => {
   return (
     <div
-      className="relative w-screen overflow-hidden"
+      className="relative w-screen overflow-hidden h-screen-vh"
       style={{ height: "100dvh" }}
     >
       {/* 3D 요소를 위한 전체 화면 Canvas */}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,7 @@
 
 :root {
   font-family: "Nanum Gothic", sans-serif;
+  --vh: 100%;
 }
 /* 모든 요소에서 스크롤바 숨기기 */
 * {

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -91,7 +91,6 @@ export const MessagePage: React.FC = () => {
         modelId={inputModelId!}
         content={inputContent}
       />
-      \
     </>
   );
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,9 @@ export default {
       animation: {
         /* 애니메이션... */
       },
+      height: {
+        "screen-vh": "calc(var(--vh)*100)",
+      },
     },
   },
   plugins: [require("tailwindcss-animate")],

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+// vite.config.ts
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
@@ -6,16 +7,16 @@ import path from "path";
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    host: true,
+    port: 5173,
+    strictPort: true,
     proxy: {
+      // '/api'로 시작하는 요청은 전부 이 타겟으로 보낸다
       "/api": {
-        target: "http://www.raindrop.my",
+        target: "https://raindrop-back.onrender.com",
         changeOrigin: true,
         secure: false,
-      },
-      "/messages": {
-        target: "http://www.raindrop.my",
-        changeOrigin: true,
-        secure: false,
+        rewrite: (path) => path.replace(/^\/api/, "/api"),
       },
     },
   },


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
## PR 제목
fix: 모바일 100vh 대응을 위한 CSS 변수 및 Tailwind 유틸 추가

## PR 요약
모바일 Safari/Chrome에서 주소창·툴바 숨김·표시 시 `100vh` 계산 오류로 레이아웃이 깨지는 문제를 해결하기 위해 CSS 커스텀 프로퍼티 `--vh`를 도입하고, Tailwind 유틸을 확장했습니다.

## 주요 변경사항
- **globals.css**에 `:root { --vh: 100%; }` 선언  
- React `App` 컴포넌트에 `useEffect`로 실제 `window.innerHeight` 기반 `--vh` 업데이트 로직 추가  
- **tailwind.config.js**에 `height.screen-vh: 'calc(var(--vh)*100)'` 유틸 확장  
- 화면 전체 높이가 필요한 컴포넌트에 `className="h-screen-vh"` 적용  

## 변경 이유
1. **주소창 숨김/표시 문제**  
   iOS 브라우저는 주소창·툴바가 나타났다 사라졌다 하며 뷰포트가 바뀌는데, CSS `100vh`는 로드 시점만 기준으로 고정됨  
2. **동적 뷰포트 반영**  
   JS의 `window.innerHeight`를 1% 단위(`--vh`)로 계산해 CSS 변수에 반영하면, 실제 보이는 화면 높이에 맞춰 레이아웃을 잡을 수 있음  
3. **Tailwind 가독성·재사용성 확보**  
   JIT arbitrary value(`h-[calc(var(--vh)*100)]`) 또는 `h-screen-vh` 유틸 클래스만으로 손쉽게 적용 가능  
4. **일관된 전체 화면 유지**  
   모바일 기기 회전·주소창 토글 등 환경 변화에도 깜빡임 없이 정확한 전체 화면 높이를 보장  

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
크롬 개발자 모드 iphone 12pro 기준
![image](https://github.com/user-attachments/assets/42d55f81-0109-4b90-bbc8-2d6ffc91c2d3)
![image](https://github.com/user-attachments/assets/1a08318b-0793-436a-9c7b-73773a580c17)
