### PR TITLE
[FEAT] 메세지 입력창 글자 수 제한

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -46,6 +46,17 @@ export const MessagePage: React.FC = () => {
     openModal("confirmBubble");
   };
 
+  const handleContentChange = (value: string) => {
+    const trimmed = value.slice(0, 50); // 50자까지만 잘라냄
+    console.log("handleContentChange.......trimmed:", trimmed);
+    setInputContent(trimmed);
+  };
+
+  const handleNickNameChange = (value: string) => {
+    const trimmed = value.slice(0, 7); // 7자까지만 잘라냄
+    setInputNickName(trimmed);
+  };
+
   if (isOwner || !isSuccess) return null;
 
   return (
@@ -67,8 +78,8 @@ export const MessagePage: React.FC = () => {
               <MessageInputBox
                 content={inputContent}
                 nickName={inputNickName}
-                onContentChange={setInputContent}
-                onNickNameChange={setInputNickName}
+                onContentChange={handleContentChange}
+                onNickNameChange={handleNickNameChange}
               />
             </div>
 

--- a/src/pages/MessagePage.tsx
+++ b/src/pages/MessagePage.tsx
@@ -48,7 +48,6 @@ export const MessagePage: React.FC = () => {
 
   const handleContentChange = (value: string) => {
     const trimmed = value.slice(0, 50); // 50자까지만 잘라냄
-    console.log("handleContentChange.......trimmed:", trimmed);
     setInputContent(trimmed);
   };
 


### PR DESCRIPTION
## 유형
<!-- PR 유형을 선택해주세요 -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 문서 수정
- [ ] 기타

## 설명
<!-- 변경 사항에 대한 간략한 설명 -->
- `MessageInputBox.tsx`
  - `Textarea`에 `maxLength={50}` 추가
  - `Input`에 `maxLength={7}` 추가
- `MessagePage.tsx`
  - 상위 컴포넌트에서 입력값이 초과되지 않도록 `slice()`로 자르는 핸들러(`handleContentChange`, `handleNickNameChange`) 추가
  - 해당 핸들러를 `MessageInputBox`에 전달하여 하위 컴포넌트에서도 입력 제어되도록 연결

## 테스트
<!-- 테스트 방법 간략하게 작성 -->
<img src="https://github.com/user-attachments/assets/6cccc880-05ba-4e94-acf6-08ef80f8f626" width="200" height="350"/>

## 이슈
<!-- 관련 이슈 번호 (PR 병합 시 자동으로 이슈가 닫히도록 'closes #이슈번호' 형식 사용) -->
closes #119
